### PR TITLE
patch: change Lucide-Ract Icons to Phosphor Icons

### DIFF
--- a/components.json
+++ b/components.json
@@ -17,5 +17,5 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "iconLibrary": "lucide"
+  "iconLibrary": "phosphor"
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "axios": "1.7.9",
     "chart.js": "4.2.1",
     "class-variance-authority": "^0.7.1",
-    "lucide-react": "^0.475.0",
     "motion": "11.15.0",
     "next": "14.2.14",
     "next-themes": "0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
-      lucide-react:
-        specifier: ^0.475.0
-        version: 0.475.0(react@18.3.1)
       motion:
         specifier: 11.15.0
         version: 11.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2414,11 +2411,6 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
-  lucide-react@0.475.0:
-    resolution: {integrity: sha512-NJzvVu1HwFVeZ+Gwq2q00KygM1aBhy/ZrhY9FsAgJtpB+E4R7uxRk9M2iKvHa6/vNxZydIB59htha4c2vvwvVg==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -6202,10 +6194,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lucide-react@0.475.0(react@18.3.1):
-    dependencies:
-      react: 18.3.1
 
   lz-string@1.5.0: {}
 

--- a/src/components/shadcn/accordion.tsx
+++ b/src/components/shadcn/accordion.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import { CaretDown } from '@phosphor-icons/react/dist/ssr';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
-import { ChevronDown } from 'lucide-react';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
@@ -34,7 +34,10 @@ const AccordionTrigger = React.forwardRef<
       {...props}
     >
       {children}
-      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+      <CaretDown
+        size={16}
+        className="shrink-0 transition-transform duration-200"
+      />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ));


### PR DESCRIPTION
## Descreva as mudanças feitas nessa PR:
Remove a biblioteca Lucide React que foi importada junto com shadcn.
Substitui o icone para a biblioteca padrão de projeto: Phophor Icons.
Atualiza a configuração do Shadcn para utilizar a Phosphor icons em componentes futuros.

## Ela resolve alguma issue? Informe o número: 
Issue #34 

## Preencha o checklist antes de enviar a PR (delete o que não usar):
- [x] Bug fix (conserta bugs e não causam modificações em outros componentes).

## Screenshots (se necessário):