### PR TITLE
PR com Adaptação do frontend às mudanças da API e correções visuais

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -8,55 +8,58 @@ import {
 } from '@phosphor-icons/react/dist/ssr';
 import type { ReactNode } from 'react';
 
+import { AdminGuard } from '@/core/auth/components/AdminGuard';
 import { HeaderBar } from '@/shared/components/layout/header/HeaderBar';
 import { Sidebar, SidebarItem } from '@/shared/components/layout/sidebar';
 
 export default function DashboardLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="relative mx-auto flex min-h-screen w-full flex-row">
-      <Sidebar>
-        <hr className="my-3 border-t border-gray-400" />
-        <SidebarItem
-          icon={<Checkerboard size={24} />}
-          text="Dashboard"
-          action="/dashboard"
-          alert
-        />
-        <SidebarItem
-          icon={<UsersFour size={24} />}
-          text="Staff"
-          action="/staff"
-        />
-        <hr className="my-3 border-t border-gray-400" />
-        <SidebarItem
-          icon={<Bookmark size={24} />}
-          text="Novel"
-          action="/noveladmin"
-        />
-        <SidebarItem
-          icon={<AddressBookTabs size={24} />}
-          text="Mangá"
-          action="/mangaadmin"
-        />
-        <SidebarItem
-          icon={<IdentificationBadge size={24} />}
-          text="Permissões"
-          action="/staffadmin"
-        />
-        <hr className="my-3 border-t border-gray-400" />
-        <SidebarItem
-          icon={<Users size={24} />}
-          text="Usuário"
-          action="/useradmin"
-        />
-      </Sidebar>
+    <AdminGuard>
+      <div className="relative mx-auto flex min-h-screen w-full flex-row">
+        <Sidebar>
+          <hr className="my-3 border-t border-gray-400" />
+          <SidebarItem
+            icon={<Checkerboard size={24} />}
+            text="Dashboard"
+            action="/dashboard"
+            alert
+          />
+          <SidebarItem
+            icon={<UsersFour size={24} />}
+            text="Staff"
+            action="/staff"
+          />
+          <hr className="my-3 border-t border-gray-400" />
+          <SidebarItem
+            icon={<Bookmark size={24} />}
+            text="Novel"
+            action="/noveladmin"
+          />
+          <SidebarItem
+            icon={<AddressBookTabs size={24} />}
+            text="Mangá"
+            action="/mangaadmin"
+          />
+          <SidebarItem
+            icon={<IdentificationBadge size={24} />}
+            text="Permissões"
+            action="/staffadmin"
+          />
+          <hr className="my-3 border-t border-gray-400" />
+          <SidebarItem
+            icon={<Users size={24} />}
+            text="Usuário"
+            action="/useradmin"
+          />
+        </Sidebar>
 
-      <main className="ml-[72px] flex w-full max-w-[calc(100dvw-72px)] flex-col pl-4 font-normal">
-        <HeaderBar className="border-b-2 border-b-slate-700" />
-        <div className="max-w-full flex-1 overflow-y-auto bg-appBackground">
-          {children}
-        </div>
-      </main>
-    </div>
+        <main className="ml-[72px] flex w-full max-w-[calc(100dvw-72px)] flex-col pl-4 font-normal">
+          <HeaderBar className="border-b-2 border-b-slate-700" />
+          <div className="max-w-full flex-1 overflow-y-auto bg-appBackground">
+            {children}
+          </div>
+        </main>
+      </div>
+    </AdminGuard>
   );
 }

--- a/src/app/(admin)/mangaadmin/page.tsx
+++ b/src/app/(admin)/mangaadmin/page.tsx
@@ -41,7 +41,7 @@ export default function NovelAdmin() {
   });
 
   const { data: arrayGenres } = usePublicGenres();
-  const genresData = arrayGenres?.map((genre) => genre.descricao) || [];
+  const genresData = arrayGenres?.map((genre) => genre.label) || [];
 
   const { mutateAsync: createComicFn } = useMutation({
     mutationFn: createComicService,

--- a/src/app/(admin)/project/[worktype]/[slug]/ProjectNovel.tsx
+++ b/src/app/(admin)/project/[worktype]/[slug]/ProjectNovel.tsx
@@ -33,7 +33,6 @@ import {
   DragAndDropSingleImage,
 } from '@/shared/components/ui/form';
 import { useToaster } from '@/shared/contexts/ToasterContext';
-import { IGenres } from '@/shared/types/common';
 
 import { Volumes } from './Volumes';
 
@@ -65,7 +64,7 @@ export function ProjectNovel() {
   const projectResponse = response?.ok ? response.data : undefined;
 
   const { data: arrayGenres } = usePublicGenres();
-  const genresData = arrayGenres?.map((genre) => genre) || []; 
+  const genresData = arrayGenres?.map((genre) => genre) || [];
 
   const { toaster } = useToaster();
 

--- a/src/app/(admin)/useradmin/page.tsx
+++ b/src/app/(admin)/useradmin/page.tsx
@@ -41,7 +41,7 @@ export default function UserAdmin() {
   });
 
   const { data: arrayGenres } = usePublicGenres();
-  const genresData = arrayGenres?.map((genre) => genre.descricao) || [];
+  const genresData = arrayGenres?.map((genre) => genre.label) || [];
 
   const { mutateAsync: createNovelFn } = useMutation({
     mutationFn: createNovelService,

--- a/src/app/(auth)/AuthCoverTile.test.tsx
+++ b/src/app/(auth)/AuthCoverTile.test.tsx
@@ -5,7 +5,7 @@ import { AuthCoverTile } from './AuthCoverTile';
 
 jest.mock('next/image', () => ({
   __esModule: true,
-  default: ({ fill, priority, sizes, ...props }: Record<string, unknown>) => (
+  default: ({ fill: _, priority: _p, sizes: _s, ...props }: Record<string, unknown>) => (
     <img {...props} />
   ),
 }));

--- a/src/app/(auth)/AuthCoverTile.test.tsx
+++ b/src/app/(auth)/AuthCoverTile.test.tsx
@@ -5,7 +5,9 @@ import { AuthCoverTile } from './AuthCoverTile';
 
 jest.mock('next/image', () => ({
   __esModule: true,
-  default: (props: React.ComponentProps<'img'>) => <img {...props} />,
+  default: ({ fill, priority, sizes, ...props }: Record<string, unknown>) => (
+    <img {...props} />
+  ),
 }));
 
 describe('AuthCoverTile', () => {

--- a/src/app/(auth)/AuthCoverTile.tsx
+++ b/src/app/(auth)/AuthCoverTile.tsx
@@ -35,7 +35,7 @@ export function AuthCoverTile({
           aria-label={alt || 'Imagem indisponível'}
           className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-[radial-gradient(circle_at_top,_rgba(34,211,238,0.18),_transparent_55%),linear-gradient(180deg,_rgba(11,29,61,0.98)_0%,_rgba(7,18,38,0.98)_100%)] p-2 text-center"
         >
-          <span className="border-authSeparator text-authSubtitle rounded-full border px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.22em]">
+          <span className="rounded-full border border-authSeparator px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.22em] text-authSubtitle">
             Tsundoku
           </span>
           <span className="text-authSubtitle/70 max-w-full truncate text-[10px] font-medium">

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -75,7 +75,7 @@ export default function AuthGroupLayout({
   return (
     <main
       style={authThemeVars}
-      className="bg-authBackground text-authText relative flex min-h-screen items-center justify-center overflow-hidden px-4 py-6 sm:px-6"
+      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-authBackground px-4 py-6 text-authText sm:px-6"
     >
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
         <div className="absolute inset-0 grid grid-cols-4 gap-2 p-2 opacity-35 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8">
@@ -112,25 +112,25 @@ export default function AuthGroupLayout({
         />
       </div>
 
-      <section className="border-authCardBorder bg-authCardBackground relative z-10 w-full max-w-md rounded-2xl border p-5 shadow-2xl backdrop-blur-lg sm:p-6">
+      <section className="relative z-10 w-full max-w-md rounded-2xl border border-authCardBorder bg-authCardBackground p-5 shadow-2xl backdrop-blur-lg sm:p-6">
         <header className="mb-5 flex flex-col items-center gap-2 text-center">
-          <span className="border-authPanelBorder bg-authPanelBackground text-authSubtitle mb-3 rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]">
+          <span className="mb-3 rounded-full border border-authPanelBorder bg-authPanelBackground px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-authSubtitle">
             Comunidade de Leitores
           </span>
 
           <Link
             href="/"
-            className="text-authHeaderText flex items-center gap-1 text-3xl font-extrabold leading-none"
+            className="flex items-center gap-1 text-3xl font-extrabold leading-none text-authHeaderText"
           >
-            <span className="text-authHeaderHighlight font-black">/</span>
+            <span className="font-black text-authHeaderHighlight">/</span>
             <span>Tsundoku</span>
-            <span className="text-authHeaderHighlight font-black">/</span>
+            <span className="font-black text-authHeaderHighlight">/</span>
           </Link>
         </header>
 
         {children}
 
-        <footer className="border-authSeparator text-authSubtitle mt-5 border-t pt-4 text-center text-xs">
+        <footer className="mt-5 border-t border-authSeparator pt-4 text-center text-xs text-authSubtitle">
           <p className="tracking-wide">Light Novels e Mangás</p>
           <p className="text-authSubtitle/75 mt-2">Tsundoku &copy; - 2026</p>
         </footer>

--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -103,8 +103,8 @@ describe('LoginPage', () => {
 
     await waitFor(() => {
       expect(loginUserServiceMock).toHaveBeenCalledWith({
-        UserName: 'usuario-teste',
-        Password: 'Senha@123',
+        Usuario: 'usuario-teste',
+        Senha: 'Senha@123',
       });
     });
 

--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -85,9 +85,9 @@ describe('LoginPage', () => {
     loginUserServiceMock.mockResolvedValue({
       ok: true,
       data: {
-        userName: 'usuario-teste',
+        usuario: 'usuario-teste',
         accessToken: validToken,
-        TsunId: 'tsun-123',
+        tsunId: 'tsun-123',
       },
     });
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -61,9 +61,9 @@ export default function LoginPage() {
       return;
     }
 
-    setUsername(result.data.userName);
+    setUsername(result.data.usuario);
     setAccessToken(result.data.accessToken);
-    setTsunId(result.data.TsunId);
+    setTsunId(result.data.tsunId);
 
     reset();
     router.push('/');

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -72,7 +72,7 @@ export default function LoginPage() {
   return (
     <div className="relative">
       <div className="mb-5 text-center">
-        <p className="text-authSubtitle text-sm">
+        <p className="text-sm text-authSubtitle">
           Entre para continuar sua leitura de onde parou.
         </p>
       </div>
@@ -102,7 +102,7 @@ export default function LoginPage() {
         />
 
         {errors.root?.message && (
-          <p className="border-authErrorBorder bg-authErrorBackground text-authErrorText rounded-md border px-3 py-2 text-sm">
+          <p className="rounded-md border border-authErrorBorder bg-authErrorBackground px-3 py-2 text-sm text-authErrorText">
             {errors.root.message}
           </p>
         )}
@@ -110,25 +110,25 @@ export default function LoginPage() {
         <button
           type="submit"
           disabled={isSubmitting}
-          className="border-authButtonBorder bg-authButtonBackground text-authButtonText hover:bg-authButtonHover inline-flex h-11 w-full items-center justify-center rounded-lg border px-4 text-sm font-semibold transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex h-11 w-full items-center justify-center rounded-lg border border-authButtonBorder bg-authButtonBackground px-4 text-sm font-semibold text-authButtonText transition-colors duration-200 hover:bg-authButtonHover disabled:cursor-not-allowed disabled:opacity-60"
         >
           {isSubmitting ? 'Entrando...' : 'Entrar'}
         </button>
       </form>
 
       <div className="text-authSubtitle/70 mt-5 flex items-center gap-3">
-        <span className="bg-authSeparator h-[1.5px] flex-1" />
+        <span className="h-[1.5px] flex-1 bg-authSeparator" />
         <span className="text-[11px] uppercase tracking-[0.18em]">
           Novo por aqui?
         </span>
-        <span className="bg-authSeparator h-[1.5px] flex-1" />
+        <span className="h-[1.5px] flex-1 bg-authSeparator" />
       </div>
 
-      <p className="text-authSubtitle mt-3 text-center text-sm">
+      <p className="mt-3 text-center text-sm text-authSubtitle">
         Não possui uma conta?{' '}
         <Link
           href="/register"
-          className="text-authHighlight hover:text-authHeaderHighlight font-semibold transition-colors"
+          className="font-semibold text-authHighlight transition-colors hover:text-authHeaderHighlight"
         >
           Crie agora
         </Link>

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -86,7 +86,7 @@ export default function RegisterPage() {
   return (
     <div className="relative">
       <div className="mb-5 text-center">
-        <p className="text-authSubtitle mt-2 text-sm">
+        <p className="mt-2 text-sm text-authSubtitle">
           Cadastre-se para acompanhar seus mangás e novels favoritos.
         </p>
       </div>
@@ -136,37 +136,37 @@ export default function RegisterPage() {
         />
 
         {errors.root?.message && (
-          <p className="border-authErrorBorder bg-authErrorBackground text-authErrorText rounded-md border px-3 py-2 text-sm">
+          <p className="rounded-md border border-authErrorBorder bg-authErrorBackground px-3 py-2 text-sm text-authErrorText">
             {errors.root.message}
           </p>
         )}
 
-        <div className="border-authSeparator bg-authPanelBackground text-authSubtitle rounded-lg border p-2.5 text-xs">
+        <div className="rounded-lg border border-authSeparator bg-authPanelBackground p-2.5 text-xs text-authSubtitle">
           Sua senha deve conter letra maiúscula, número e caractere especial.
         </div>
 
         <button
           type="submit"
           disabled={isSubmitting}
-          className="border-authButtonBorder bg-authButtonBackground text-authButtonText hover:bg-authButtonHover inline-flex h-11 w-full items-center justify-center rounded-lg border px-4 text-sm font-semibold transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex h-11 w-full items-center justify-center rounded-lg border border-authButtonBorder bg-authButtonBackground px-4 text-sm font-semibold text-authButtonText transition-colors duration-200 hover:bg-authButtonHover disabled:cursor-not-allowed disabled:opacity-60"
         >
           {isSubmitting ? 'Cadastrando...' : 'Cadastrar'}
         </button>
       </form>
 
       <div className="text-authSubtitle/70 mt-5 flex items-center gap-3">
-        <span className="bg-authSeparator h-[1.5px] flex-1" />
+        <span className="h-[1.5px] flex-1 bg-authSeparator" />
         <span className="text-[11px] uppercase tracking-[0.18em]">
           Já tem conta?
         </span>
-        <span className="bg-authSeparator h-[1.5px] flex-1" />
+        <span className="h-[1.5px] flex-1 bg-authSeparator" />
       </div>
 
-      <p className="text-authSubtitle mt-3 text-center text-sm">
+      <p className="mt-3 text-center text-sm text-authSubtitle">
         Já possui conta?{' '}
         <Link
           href="/login"
-          className="text-authHighlight hover:text-authHeaderHighlight font-semibold transition-colors"
+          className="font-semibold text-authHighlight transition-colors hover:text-authHeaderHighlight"
         >
           Entrar
         </Link>

--- a/src/app/(webapp)/(projects)/comics/page.tsx
+++ b/src/app/(webapp)/(projects)/comics/page.tsx
@@ -40,7 +40,7 @@ export default function Comics() {
   useEffect(() => {
     if (genresResponse) {
       const genresOrdered = genresResponse.sort((a, b) =>
-        a.descricao.localeCompare(b.descricao),
+        a.label.localeCompare(b.label),
       );
       setGenresList(genresOrdered);
     }
@@ -87,7 +87,7 @@ export default function Comics() {
 
     if (projectsResponse?.data) {
       const filtered = projectsResponse?.data.filter((item) => {
-        return item.listaGeneros.some((g: IGenres) => g.descricao === genre);
+        return item.listaGeneros.some((g: IGenres) => g.label === genre);
       });
 
       setComicList(filtered);
@@ -127,11 +127,11 @@ export default function Comics() {
       >
         {genresList.map((genre) => (
           <DropdownOption
-            key={genre.id}
-            label={genre.descricao}
-            onClick={() => findByGenre(genre.descricao)}
-            value={genre.descricao}
-            selected={genre.descricao === genres}
+            key={genre.value}
+            label={genre.label}
+            onClick={() => findByGenre(genre.label)}
+            value={genre.value}
+            selected={genre.label === genres}
           />
         ))}
       </DropdownContainer>

--- a/src/app/reader/comics/[slug]/[chapter]/page.tsx
+++ b/src/app/reader/comics/[slug]/[chapter]/page.tsx
@@ -61,7 +61,7 @@ export default function ComicReader({
           publicado: chapter.publicado,
           ordemCapitulo: chapter.ordemCapitulo,
           slug: chapter.slug,
-          descritivoCapitulo: chapter.descritivoCapitulo,
+          descritivoCapitulo: chapter.descritivoCapitulo || chapter.slug.replace(/-/g, ' '),
           dataInclusao: chapter.dataInclusao,
         }),
       );
@@ -97,7 +97,7 @@ export default function ComicReader({
 
   return (
     <div ref={comicContainerRef} className="relative h-[100vh] pt-[88px]">
-      <ActionsBar removeList={['reader']}>
+      <ActionsBar removeList={['reader']} className="bg-[var(--reader-color-background)]">
         <ActionChapterList
           totalChapters={chapterListData.length}
           currentChapter={slugChapter ? slugChapter!.replace(/-/g, ' ') : '0'}

--- a/src/app/reader/layout.tsx
+++ b/src/app/reader/layout.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 export default function ReaderLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="flex min-h-screen w-full flex-col bg-[var(--reader-color-background)] text-appText">
+    <div className="flex min-h-screen w-full flex-col bg-appBackground text-appText">
       <main className="flex-grow">{children}</main>
     </div>
   );

--- a/src/app/reader/novels/[slug]/[chapter]/page.tsx
+++ b/src/app/reader/novels/[slug]/[chapter]/page.tsx
@@ -74,7 +74,7 @@ export default function NovelReader({ params }: PageProps) {
   return (
     <div className="relative pb-10 pt-[88px]">
       <ScrollProgressAnimation onTop>
-        <ActionsBar removeList={['reader']} isReader>
+        <ActionsBar removeList={['reader']} isReader className="bg-[var(--reader-color-background)]">
           <ActionChapterWithVolumeList />
           <ActionFontFamilyControl onChange={setFontFamily} />
           <ActionFontSizeControl onChange={setFontSize} />

--- a/src/core/api/refreshToken.ts
+++ b/src/core/api/refreshToken.ts
@@ -16,7 +16,7 @@ export const refreshAccessToken = async () => {
   isRefreshing = true;
 
   try {
-    const { data } = await auth.get('/auth/refresh-token');
+    const { data } = await auth.get('refresh-token');
 
     useAuthStore.getState().setAccessToken(data.accessToken);
 

--- a/src/core/auth/components/AdminGuard.tsx
+++ b/src/core/auth/components/AdminGuard.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, type ReactNode } from 'react';
+
+import { useAuthStore } from '@/core/auth/stores/useAuthStore';
+
+export function AdminGuard({ children }: { children: ReactNode }) {
+  const { username, position, isPending } = useAuthStore();
+  const router = useRouter();
+
+  const isAuthorized = username && (position === 'Admin' || position === 'Staff');
+
+  useEffect(() => {
+    if (isPending) return;
+
+    if (!isAuthorized) {
+      router.replace('/');
+    }
+  }, [isPending, isAuthorized, router]);
+
+  if (isPending) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center bg-appBackground">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-appMenuBorder border-t-appHeaderHighlight" />
+      </div>
+    );
+  }
+
+  if (!isAuthorized) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/src/core/auth/hooks/useAuthHydration.ts
+++ b/src/core/auth/hooks/useAuthHydration.ts
@@ -26,11 +26,11 @@ export const useAuthHydration = () => {
     const hydrateAuth = async () => {
       setIsPending(true);
       try {
-        const { data } = await auth.get('/auth/refresh-token');
+        const { data } = await auth.get('refresh-token');
 
         setAccessToken(data.accessToken);
-        setUsername(data.userName);
-        setTsunId(data.TsunId);
+        setUsername(data.usuario);
+        setTsunId(data.tsunId);
       } catch (error) {
         console.log('Fail to refresh token in useAuthHydration');
       } finally {

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -13,7 +13,7 @@ export const createUserService = async (
   dataRequest: IUserRegisterData,
 ): Promise<ApiResponse<IUserRegisterResponse>> => {
   try {
-    const { data } = await auth.post('/auth/cadastro', dataRequest);
+    const { data } = await auth.post('auth/cadastro', dataRequest);
     return { ok: true, data };
   } catch (error) {
     return {
@@ -27,7 +27,7 @@ export const loginUserService = async (
   dataRequest: IUserLoginData,
 ): Promise<ApiResponse<IUserLoginResponse>> => {
   try {
-    const { data } = await auth.post('/auth/login', dataRequest);
+    const { data } = await auth.post('auth/login', dataRequest);
     return { ok: true, data };
   } catch (error) {
     return {

--- a/src/features/auth/api/types.ts
+++ b/src/features/auth/api/types.ts
@@ -16,7 +16,7 @@ export interface IUserLoginData {
 }
 
 export interface IUserLoginResponse {
-  userName: string;
+  usuario: string;
   accessToken: string;
-  TsunId: string;
+  tsunId: string;
 }

--- a/src/features/project/components/ProjectData.tsx
+++ b/src/features/project/components/ProjectData.tsx
@@ -51,8 +51,8 @@ export function ProjectData({
         <span className="font-bold">Gêneros:</span>
         {genres.map((genre) => (
           <Tag
-            key={typeof genre === 'string' ? genre : genre.slug}
-            text={typeof genre === 'string' ? genre : genre.descricao}
+            key={typeof genre === 'string' ? genre : genre.value}
+            text={typeof genre === 'string' ? genre : genre.label}
           />
         ))}
       </div>

--- a/src/features/project/components/comic/ComicData.tsx
+++ b/src/features/project/components/comic/ComicData.tsx
@@ -31,7 +31,7 @@ export function ComicData({ title, comicSlug }: ComicDataProps) {
           publicado: chapter.publicado,
           ordemCapitulo: chapter.ordemCapitulo,
           slug: chapter.slug,
-          descritivoCapitulo: chapter.descritivoCapitulo,
+          descritivoCapitulo: chapter.descritivoCapitulo || chapter.slug.replace(/-/g, ' '),
           dataInclusao: chapter.dataInclusao,
         }),
       );

--- a/src/features/reader/components/ActionsBar/index.tsx
+++ b/src/features/reader/components/ActionsBar/index.tsx
@@ -5,6 +5,7 @@ import { type ComponentProps, type ReactNode } from 'react';
 import { HeaderButtonLogin } from '@/shared/components/layout/header/HeaderButtonLogin';
 import { Breadcrump } from '@/shared/components/ui/Breadcrump';
 import { ThemeToggle } from '@/shared/components/ui/theme/ThemeToggle';
+import { cn } from '@/shared/utils/cn';
 
 interface ActionsBarProps extends ComponentProps<'div'> {
   sufixList?: string[];
@@ -18,11 +19,15 @@ export function ActionsBar({
   removeList = [],
   isReader,
   children,
+  className,
   ...props
 }: ActionsBarProps) {
   return (
     <div
-      className="fixed left-0 top-0 z-50 flex w-full flex-col gap-2 bg-appBackground px-2 py-3 shadow-sm sm:flex-row sm:items-center sm:justify-between sm:px-6 sm:py-4"
+      className={cn(
+        'fixed left-0 top-0 z-50 flex w-full flex-col gap-2 bg-appBackground px-2 py-3 shadow-sm sm:flex-row sm:items-center sm:justify-between sm:px-6 sm:py-4',
+        className,
+      )}
       {...props}
     >
       <div className="flex w-full items-center justify-between sm:w-auto sm:flex-1">

--- a/src/features/reader/components/controls/__snapshots__/ActionButtonControl.test.tsx.snap
+++ b/src/features/reader/components/controls/__snapshots__/ActionButtonControl.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Testes para o componente <ActionButtonControl /> Teste de snapshot Deve manter o snapshot do ActionButtonControl 1`] = `
 <div>
   <button
-    class="inline-flex h-10 w-full items-center justify-between rounded-lg border border-appMenuBorder bg-appMenuBackground px-4 py-2 text-sm font-medium text-appText hover:text-zinc-400 focus:outline-none"
+    class="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-appMenuBorder bg-appInputBackground px-2 py-2 text-sm font-medium text-appText hover:bg-appGroupBackground focus:outline-none sm:w-full sm:justify-between sm:px-4"
     role="button"
   >
     Clique aqui

--- a/src/features/reader/utils/ReaderProgressBar.tsx
+++ b/src/features/reader/utils/ReaderProgressBar.tsx
@@ -33,7 +33,7 @@ export function ReaderProgressBar({
 
   return (
     <div
-      className="fixed bottom-0 left-0 w-full bg-white shadow-inner dark:bg-zinc-950"
+      className="fixed bottom-0 left-0 w-full bg-[var(--reader-color-background)] shadow-inner"
       {...props}
     >
       <div className="flex items-center justify-between">

--- a/src/shared/components/layout/header/HeaderButtonLogin.tsx
+++ b/src/shared/components/layout/header/HeaderButtonLogin.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { Spinner, User, UserCircle } from '@phosphor-icons/react/dist/ssr';
-import { ChevronDown, LayoutDashboard, LogOut } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import { ChevronDown, ExternalLink, LayoutDashboard, LogOut } from 'lucide-react';
+import { usePathname, useRouter } from 'next/navigation';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { auth } from '@/core/api';
@@ -27,13 +27,20 @@ export function HeaderButtonLogin({
   const { toaster } = useToaster();
   const { username, logout, position, isPending } = useAuthStore();
   const router = useRouter();
+  const pathname = usePathname();
 
   const isLogged = username;
+  const adminRoutes = ['/dashboard', '/staff', '/noveladmin', '/mangaadmin', '/staffadmin', '/useradmin'];
+  const isOnAdmin = adminRoutes.some((route) => pathname.startsWith(route));
 
   async function handleLogout() {
-    await auth.get('logout');
+    await auth.get('auth/logout');
     logout();
     setIsOpen(false);
+
+    if (isOnAdmin) {
+      router.push('/');
+    }
 
     toaster({
       type: 'info',
@@ -41,9 +48,8 @@ export function HeaderButtonLogin({
     });
   }
 
-  function handleLogin() {    
-    //router.push('/login');
-    router.push('/dashboard');
+  function handleLogin() {
+    router.push('/login');
   }
 
   const handleClickOutside = (event: MouseEvent) => {
@@ -87,7 +93,20 @@ export function HeaderButtonLogin({
   };
 
   const ItemsStaff = () => {
-    if (position !== 'Admin' && position !== 'Staff') return; 
+    if (position !== 'Admin' && position !== 'Staff') return;
+
+    if (isOnAdmin) {
+      return (
+        <ItemList
+          icon={<ExternalLink size={16} />}
+          text="Ver Site"
+          action={() => {
+            router.push('/');
+            setIsOpen(false);
+          }}
+        />
+      );
+    }
 
     return (
       <ItemList

--- a/src/shared/components/layout/header/HeaderMenu.tsx
+++ b/src/shared/components/layout/header/HeaderMenu.tsx
@@ -1,5 +1,6 @@
 import { List } from '@phosphor-icons/react/dist/ssr';
 import { LogOut } from 'lucide-react';
+import { usePathname, useRouter } from 'next/navigation';
 import { useRef, useState } from 'react';
 
 import { auth } from '@/core/api';
@@ -28,16 +29,25 @@ export function HeaderMenu() {
   const [open, setOpen] = useState(false);
   const { toaster } = useToaster();
   const { username, position, logout } = useAuthStore();
+  const router = useRouter();
+  const pathname = usePathname();
 
   const isLogged = Boolean(username);
   const canAccessAdmin = position === 'Admin' || position === 'Staff';
+  const adminRoutes = ['/dashboard', '/staff', '/noveladmin', '/mangaadmin', '/staffadmin', '/useradmin'];
+  const isOnAdmin = adminRoutes.some((route) => pathname.startsWith(route));
 
   const handleLogout = async () => {
     try {
-      await auth.get('logout');
+      await auth.get('auth/logout');
     } finally {
       logout();
       setOpen(false);
+
+      if (isOnAdmin) {
+        router.push('/');
+      }
+
       toaster({
         type: 'info',
         msg: 'Voce saiu da sua conta. Ate breve!',
@@ -169,8 +179,8 @@ export function HeaderMenu() {
                     {canAccessAdmin && (
                       <DialogClose asChild>
                         <LinkButton
-                          text="Administracao"
-                          action="/dashboard"
+                          text={isOnAdmin ? 'Ver Site' : 'Administracao'}
+                          action={isOnAdmin ? '/' : '/dashboard'}
                           className={cn(
                             'inline-flex h-11 w-full items-center justify-center gap-2 rounded-md border border-appMenuBorder px-3 text-sm font-semibold text-appMenuText hover:bg-appMenuHover',
                           )}


### PR DESCRIPTION
## Descreva as mudanças feitas nessa PR:
- Correção das rotas de autenticação (base URL `/api/auth/` → `/api/`, paths ajustados para login, cadastro, logout e refresh-token)
- Atualização dos campos da resposta de login (`userName` → `usuario`, `TsunId` → `tsunId`) para refletir o novo contrato da API
- Proteção das rotas admin com `AdminGuard` (redireciona usuários não autenticados ou sem role Admin/Staff para `/`)
- Menu contextual do header: exibe "Ver Site" ao invés de "Dashboard" quando já está no painel admin; logout no dashboard redireciona para `/`
- Correção do dropdown de capítulos vazio no reader (fallback usando `slug` quando `descritivoCapitulo` não vem da API)
- Correção das cores do reader (navbar com cor escura do reader, fundo claro, progress bar consistente entre temas)
- `ActionsBar` agora aceita `className` customizado via `cn()`

## Ela resolve alguma issue? Informe o número:
N/A

## Preencha o checklist antes de enviar a PR (delete o que não usar):
N/A

## Screenshots (se necessário):
N/A